### PR TITLE
Make error messages readable on non-hdpi screens

### DIFF
--- a/styles/error-highlighting.less
+++ b/styles/error-highlighting.less
@@ -5,7 +5,8 @@
   color: rgb(203, 204, 205);
   padding: 4px;
   border-radius: 4px;
-  font-family: monospace;
+  font-family: var(--editor-font-family);
+  font-size: 13px;
 }
 
 // Dull colors


### PR DESCRIPTION
The error messages are very difficult to read due to the small font, low contrast between the font color and bg color, and the font smoothing. While it is okay when looking at it on e.g. a MacBook it becomes very hard to read on an external monitor with a bit lower pixel density.

Just using the editors font and and slightly increasing the font size makes it perfect.