### PR TITLE
[Linter v2] Upgrade to new Linter API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ https://atom.io/packages/elmjutsu
 * Install [Elm](http://elm-lang.org/install).
 * Install [language-elm](https://atom.io/packages/language-elm) (no need to install `elm-oracle` or `goto`).
 * For `Error Highlighting`:
-  * Install [atom-ide-ui](https://atom.io/packages/atom-ide-ui) or [linter@2.2.0](https://atom.io/packages/linter) (legacy version) + [linter-ui-default](https://atom.io/packages/linter-ui-default).
+  * Install [atom-ide-ui](https://atom.io/packages/atom-ide-ui) or [linter](https://atom.io/packages/linter) + [linter-ui-default](https://atom.io/packages/linter-ui-default).
+  * With linter v2 API (linter 2.3.0 and above), tooltips are collapsed by default. You have to click expand buttons (">"), or bind `linter-ui-default:expand-tooltip` to some key and hold it to expand them.
 * For `Go to Definition`:
   * Install [atom-ide-ui](https://atom.io/packages/atom-ide-ui) or [hyperclick](https://atom.io/packages/hyperclick) (both optional).
 * For `Autocomplete`:
@@ -469,7 +470,7 @@ Adds an alias to the added import (see [Add Import](#elmjutsu-add-import)).
 ## <a name="keybindings"></a>Keybindings
 
 Here is an example:
-```
+```cson
 'atom-text-editor:not([mini])[data-grammar^="source elm"]':
   'f12': 'elmjutsu:go-to-definition'
   'ctrl-r': 'elmjutsu:go-to-symbol'
@@ -488,6 +489,7 @@ Here is an example:
 'atom-workspace':
   'f1': 'elmjutsu:toggle-sidekick'
   'ctrl-shift-f12': 'elmjutsu:hide-usages-panel'
+  'ctrl': 'linter-ui-default:expand-tooltip' # For linter and linter-ui-default users
 ```
 <!--
 'atom-text-editor':

--- a/lib/elm-make-runner.js
+++ b/lib/elm-make-runner.js
@@ -473,7 +473,7 @@ export default class ElmMakeRunner {
                 },
               ];
               let issue = formatIssue(
-                'WARNING',
+                'MISSING TYPE ANNOTATION',
                 filePath,
                 message,
                 range,

--- a/lib/elm-make-runner.js
+++ b/lib/elm-make-runner.js
@@ -808,7 +808,7 @@ export default class ElmMakeRunner {
   }
 }
 
-function formatIssue(filePath, message, range, type) {
+function formatIssue(title, filePath, message, range, severity) {
   const messagesEnhanced =
     atom.config.get('elmjutsu.enhancedElmMakeMessages') === true;
   if (messagesEnhanced) {
@@ -824,10 +824,13 @@ function formatIssue(filePath, message, range, type) {
     range = range.translate([0, 0], [0, 1]);
   }
   return {
-    type: type || 'error',
-    html: renderToStaticMarkup(jsx),
-    filePath,
-    range,
+    severity: severity || 'error',
+    excerpt: title,
+    description: renderToStaticMarkup(jsx),
+    location: {
+      file: filePath,
+      position: range,
+    },
   };
 }
 

--- a/lib/elm-make-runner.js
+++ b/lib/elm-make-runner.js
@@ -265,6 +265,7 @@ export default class ElmMakeRunner {
                       ]
                     );
                     return formatIssue(
+                      problem.title,
                       this.toProblemFilePath(error.path, projectDirectory),
                       problem.message,
                       range
@@ -312,7 +313,7 @@ export default class ElmMakeRunner {
                 },
               ]);
               return resolve([
-                formatIssue(editorFilePath, result.message, range),
+                formatIssue('ERROR', editorFilePath, result.message, range),
               ]);
             }
           }
@@ -471,7 +472,13 @@ export default class ElmMakeRunner {
                   underline: false,
                 },
               ];
-              let issue = formatIssue(filePath, message, range, 'warning');
+              let issue = formatIssue(
+                'WARNING',
+                filePath,
+                message,
+                range,
+                'warning'
+              );
               issue.filePath = filePath;
               issue.message = message;
               return issue;

--- a/lib/main.js
+++ b/lib/main.js
@@ -298,7 +298,7 @@ export default {
       name: 'Elm',
       grammarScopes: ['source.elm'],
       scope: 'project',
-      lintOnFly: false,
+      lintsOnChange: false,
       lint(editor) {
         return self.elmMakeRunner.compile(editor);
       },
@@ -306,7 +306,7 @@ export default {
     this.subscriptions.add(
       atom.config.observe('elmjutsu.runElmMake', mode => {
         const lintOnTheFly = mode === 'on the fly';
-        linter.lintOnFly = lintOnTheFly;
+        linter.lintsOnChange = lintOnTheFly;
       })
     );
     return linter;

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     },
     "linter": {
       "versions": {
-        "1.0.0": "provideLinter"
+        "2.0.0": "provideLinter"
       }
     },
     "code-actions": {


### PR DESCRIPTION
Attempts to resolve https://github.com/halohalospecial/atom-elmjutsu/issues/153

Since Linter 2.3.0 dropped Linter v1 API support, this patch upgrades Linter provider of Elmjutsu to be compatible with Linter v2 API.

I had tested this with Linter 2.3.0, linter-ui-default 1.7.1, and it *seemingly* works, but definitely require other people's eyes. Especially, I have not checked every kind of possible messages that can be emitted from elm compiler.

As stated in [upgrade instruction](https://steelbrain.me/linter/guides/upgrading-to-standard-linter-v2.html):

- `type` is now `severity`
- `filePath` & `range` combination is now contained in `location` object
- `html` is removed and `description` added

Also, not explicitly stated but:

- `text` is replaced with `excerpt` and is now mandatory
- It says `description` accepts markdown, though subset of HTML is valid in markdown, it can actually handle HTML as well (as long as it is sanitized and not contain prohibited tags, I assume)
    - As long as currently-used JSX formatting and `renderToStaticMarkup()` produces mostly simple and sanitized HTML, it *should* work

Other things I found:

- Messages provided from v2 API are, when consumed, shown in collapsed form by default
![image](https://user-images.githubusercontent.com/4507126/52994612-833d1f00-345b-11e9-9ea2-a620ca5aa5f7.png)
- We can expand this and reveal marked-up description, by clicking ">" icon to the left, or invoke `linter-ui-default:expand-tooltip` command
![image](https://user-images.githubusercontent.com/4507126/52994665-b384bd80-345b-11e9-8fd8-87087c7d2f6d.png)
- Tooltip expansion (`linter-ui-default:expand-tooltip`) is key-bindable. Though it behaves in "expand while holding the key" manner.
    - This is similar to `atom-ide-ui` I believe? And it is actually nice since it will not block our line-of-sight to actual buffer with large tooltip!
    - Keybind sample is like this:
        ```cson
        'atom-workspace':
          'ctrl': 'linter-ui-default:expand-tooltip'
        ```
    - Added this to README.md
- In [v2 Messages](https://steelbrain.me/linter/types/linter-message-v2.html), there are `solutions` property for quick fixes, and `references` property for in-project references.
    - Current Quick Fixes can be also plugged into new `solutions` property, since it now allows arbitrary function invocation, not just text replacement. Though at a glance, it require some extra work :P
    - It is aesthetically poor in linter-ui-default (plain "FIX" button on tooltip) compared to atom-ide-ui's code actions, though definitely better than nothing!