### PR TITLE
Support test files that are not in tests/

### DIFF
--- a/lib/elm-make-runner.js
+++ b/lib/elm-make-runner.js
@@ -136,9 +136,7 @@ export default class ElmMakeRunner {
       atom.config.get('elmjutsu.alwaysCompileMain') === true;
 
     const isTestFilePath =
-      editorFilePath.startsWith(
-        path.resolve(projectDirectory, 'tests') + path.sep
-      ) || isInsideTestDirectory;
+      editorFilePath.endsWith('Test.elm') || isInsideTestDirectory;
 
     let filePathsToCompile = [];
     if (alwaysCompileMain) {
@@ -167,16 +165,15 @@ export default class ElmMakeRunner {
         }
       }
     } else {
-      if (isTestFilePath && process.platform === 'win32') {
-        // Workaround for https://github.com/halohalospecial/atom-elmjutsu/issues/131#issuecomment-429445645
-        const relativeEditorFilePath = path.relative(
-          projectDirectory,
-          editorFilePath
-        );
-        filePathsToCompile = [relativeEditorFilePath];
-      } else {
-        filePathsToCompile = [editorFilePath];
-      }
+      filePathsToCompile = [editorFilePath];
+    }
+
+    if (isTestFilePath) {
+      const relativeEditorFilePath = path.relative(
+        projectDirectory,
+        editorFilePath
+      );
+      filePathsToCompile = [relativeEditorFilePath];
     }
 
     let args = [


### PR DESCRIPTION
Some projects prefer to put tests files alongside the source. We can
identify these files by checking that they end with "Test.elm".